### PR TITLE
feat(core): implement parse flag and define const flag config

### DIFF
--- a/cmd/cli/common.go
+++ b/cmd/cli/common.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// configVar [TODO:description]
+func configVar(cmd *cobra.Command, key string, defaultValue interface{}, description string, vp *viper.Viper) error {
+	flags := cmd.PersistentFlags()
+	flagSet := reflect.ValueOf(defaultValue)
+	flagType := flagSet.Type()
+
+	switch flagType.Kind() {
+	case reflect.Bool:
+		flags.Bool(key, defaultValue.(bool), description)
+	case reflect.Int:
+		flags.Int(key, defaultValue.(int), description)
+	case reflect.String:
+		flags.String(key, defaultValue.(string), description)
+	case reflect.Slice:
+		if flagType.Elem().Kind() == reflect.String {
+			flags.StringSlice(key, defaultValue.([]string), description)
+		} else {
+			return fmt.Errorf("unsupported slice type for key: %s", key)
+		}
+	// TODO: Support another type if needed.
+	default:
+		return fmt.Errorf("unsupported flag type for key: %s", key)
+	}
+
+	err := vp.BindPFlag(key, flags.Lookup(key))
+	if err != nil {
+		return fmt.Errorf("failed to bind flag '%s': %w", key, err)
+	}
+
+	return nil
+}

--- a/cmd/cli/init.go
+++ b/cmd/cli/init.go
@@ -11,6 +11,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	cfgSecretShares    = "secret-shares"
+	cfgSecretThreshold = "secret-threshold"
+)
+
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize the target Vault instance",
@@ -44,5 +49,8 @@ It will not unseal the Vault instance after initializing.`,
 }
 
 func init() {
+	configVar(initCmd, cfgSecretShares, 5, "Number of keys that Vault will create during the initialization step.", c)
+	configVar(initCmd, cfgSecretThreshold, 3, "Number of keys required to unseal Vault.", c)
+
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -8,14 +8,22 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var Version = "dev"
 
+const cfgVaultAddress = "vault-addr"
+
+const cfgConfigPath = "config-path"
+
+var c = viper.New()
+
 var rootCmd = &cobra.Command{
-	Use:   "vault-agent-cli",
-	Short: "Sync configurations, secrets of Hashicorp Vault",
-	Long:  "This is a tool to help setup, management of Hashicorp Vault.",
+	Use:     "vault-agent-cli",
+	Short:   "Sync configurations, secrets of Hashicorp Vault",
+	Version: Version, // TODO: Implement versioning via another command
+	Long:    "This is a tool to help setup, management of Hashicorp Vault.",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 	},
 }
@@ -36,7 +44,8 @@ func execute() {
 }
 
 func init() {
-	// TODO: Parse configurations
+	configVar(rootCmd, cfgVaultAddress, "http://127.0.0.1:8200", "The URL of the remote Vault", c)
+	configVar(rootCmd, cfgConfigPath, "", "The configs file path", c)
 }
 
 func main() {


### PR DESCRIPTION
## Pull Request: Implement Configuration via Command Line Flags

This pull request introduces a new mechanism for configuring the `vault-agent-cli` tool using command-line flags.  This improves usability and flexibility by allowing users to override default settings without modifying configuration files.

**Summary of Changes:**

This PR adds support for command-line flags to configure various aspects of the `vault-agent-cli` tool.  This includes the Vault address and the path to the configuration file.  Additionally, the `init` command now supports specifying the number of secret shares and the threshold for unsealing Vault.

**Files Changed:**

- **`cmd/cli/common.go` (new file):** This file introduces the `configVar` function, which is a helper function to simplify the process of binding command-line flags to Viper configuration.  This function handles different data types and provides error handling for unsupported types.

- **`cmd/cli/init.go`:** This file has been modified to use the `configVar` function to add command-line flags for `secret-shares` and `secret-threshold` to the `init` command.  This allows users to customize these parameters during initialization.

- **`cmd/cli/main.go`:** This file has been modified to use the `configVar` function to add command-line flags for `vault-addr` (Vault address) and `config-path` (path to configuration file).  The `Version` constant is also added to the `rootCmd` for future versioning.

**Code Changes:**

The core change is the introduction of the `configVar` function in `cmd/cli/common.go`:

```go
// configVar [TODO:description]
func configVar(cmd *cobra.Command, key string, defaultValue interface{}, description string, vp *viper.Viper) error {
	flags := cmd.PersistentFlags()
	flagSet := reflect.ValueOf(defaultValue)
	flagType := flagSet.Type()

	switch flagType.Kind() {
	case reflect.Bool:
		flags.Bool(key, defaultValue.(bool), description)
	case reflect.Int:
		flags.Int(key, defaultValue.(int), description)
	case reflect.String:
		flags.String(key, defaultValue.(string), description)
	case reflect.Slice:
		if flagType.Elem().Kind() == reflect.String {
			flags.StringSlice(key, defaultValue.([]string), description)
		} else {
			return fmt.Errorf("unsupported slice type for key: %s", key)
		}
	// TODO: Support another type if needed.
	default:
		return fmt.Errorf("unsupported flag type for key: %s", key)
	}

	err := vp.BindPFlag(key, flags.Lookup(key))
	if err != nil {
		return fmt.Errorf("failed to bind flag '%s': %w", key, err)
	}

	return nil
}
```

This function simplifies the process of adding flags and binding them to Viper, improving code readability and maintainability.


**Reason for Changes:**

This change enhances the user experience by providing a more flexible and convenient way to configure the tool.  Users can now easily override default settings via command-line arguments, eliminating the need to modify configuration files.

**Impact of Changes:**

This change introduces a significant improvement in the usability and flexibility of the `vault-agent-cli` tool.  Users can now configure the tool more easily and tailor it to their specific needs without modifying configuration files.

**Test Plan:**

- Unit tests should be added to verify the functionality of the `configVar` function and the correct parsing of command-line flags.
- Integration tests should be implemented to ensure that the configuration values are correctly applied when using command-line flags.

**Additional Notes:**

- The `TODO` comments in the code should be addressed in future PRs to improve code clarity and maintainability.  Specifically, the `TODO:description` comment in `configVar` should be replaced with a descriptive comment.
-  The `Version` in `main.go` is currently set to `"dev"`.  A mechanism for proper versioning should be implemented in a future PR.  This could involve using build tags or a versioning system.

